### PR TITLE
Feat: Archive Live Streams

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { ChannelsRepository } from './channels/channels.repository';
 import { UsersRepository } from './users/users.repository';
 import { ScheduleModule } from '@nestjs/schedule';
 import { MetricsModule } from './metrics/metrics.module';
+import { LiveModule } from './live/live.module';
 
 @Module({
   imports: [
@@ -84,6 +85,8 @@ import { MetricsModule } from './metrics/metrics.module';
     ScheduleModule.forRoot(),
 
     MetricsModule,
+
+    LiveModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,7 @@ import { UsersRepository } from './users/users.repository';
 import { ScheduleModule } from '@nestjs/schedule';
 import { MetricsModule } from './metrics/metrics.module';
 import { LiveModule } from './live/live.module';
+import { LiveRepository } from './live/live.repository';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { LiveModule } from './live/live.module';
       VodsRepository,
       ChannelsRepository,
       UsersRepository,
+      LiveRepository
     ]),
 
     AuthModule,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -13,11 +13,12 @@ export class AuthService {
     @InjectRepository(UsersRepository)
     private usersRepository: UsersRepository,
     private jwtService: JwtService,
-  ) {}
+  ) { }
   async login(authCredentialsDto: AuthCredentialsDto) {
     const { username, password } = authCredentialsDto;
 
-    const user = await this.usersRepository.findUser(username);
+    const user = await this.usersRepository.createQueryBuilder("user").where("user.username = :username", { username }).addSelect("user.password").getOne();
+
     if (!user) {
       throw new UnauthorizedException('Invalid credentials');
     }

--- a/src/exec/exec.module.ts
+++ b/src/exec/exec.module.ts
@@ -20,4 +20,4 @@ import { ExecService } from './exec.service';
   ],
   providers: [ExecService, QueuesService, FilesService, ConfigService],
 })
-export class ExecModule {}
+export class ExecModule { }

--- a/src/exec/exec.module.ts
+++ b/src/exec/exec.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FilesService } from 'src/files/files.service';
+import { LiveRepository } from 'src/live/live.repository';
 import { QueuesRepository } from 'src/queues/queues.repository';
 import { QueuesService } from 'src/queues/queues.service';
 import { UsersRepository } from 'src/users/users.repository';
@@ -15,6 +16,7 @@ import { ExecService } from './exec.service';
       QueuesRepository,
       VodsRepository,
       UsersRepository,
+      LiveRepository
     ]),
     HttpModule,
   ],

--- a/src/exec/exec.service.ts
+++ b/src/exec/exec.service.ts
@@ -371,6 +371,9 @@ export class ExecService {
     // !Archive Live Chat
     //?
     let downloadChatChild;
+    this.logger.debug('Chat download requested')
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    this.logger.debug('Chat download started')
     try {
       this.logger.verbose(`Spawning chat downloader for live stream ${streamInfo.id}`);
       downloadChatChild = child.spawn('chat_downloader', [

--- a/src/files/files.module.ts
+++ b/src/files/files.module.ts
@@ -18,4 +18,4 @@ import { FilesService } from './files.service';
   ],
   providers: [FilesService, QueuesService],
 })
-export class FilesModule {}
+export class FilesModule { }

--- a/src/files/files.module.ts
+++ b/src/files/files.module.ts
@@ -1,6 +1,7 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { LiveRepository } from 'src/live/live.repository';
 import { QueuesRepository } from 'src/queues/queues.repository';
 import { QueuesService } from 'src/queues/queues.service';
 import { UsersRepository } from 'src/users/users.repository';
@@ -13,6 +14,7 @@ import { FilesService } from './files.service';
       QueuesRepository,
       VodsRepository,
       UsersRepository,
+      LiveRepository
     ]),
     HttpModule,
   ],

--- a/src/files/files.service.ts
+++ b/src/files/files.service.ts
@@ -11,7 +11,9 @@ import * as cpy from 'cpy';
 @Injectable()
 export class FilesService {
   private logger = new Logger('FilesService');
-  constructor(private httpService: HttpService) { }
+  constructor(
+    private httpService: HttpService,
+  ) { }
   async createFolder(folderName: string) {
     try {
       if (await !fs.existsSync(`/mnt/vods/${folderName}`)) {
@@ -81,6 +83,88 @@ export class FilesService {
     } catch (error) {
       this.logger.error('Error deleting folder', error);
       throw new InternalServerErrorException(`Error deleting folder ${path}`);
+    }
+  }
+  async liveChatParser(path: string, streamInfo) {
+    try {
+      let newChatJson = {
+        "streamer": {
+          "name": streamInfo.user_name,
+          "id": streamInfo.user_id
+        },
+        "comments": []
+      }
+      // Read live stream chat
+      const chatFile = fs.readFileSync(path, 'utf8')
+      const chatJson = JSON.parse(chatFile)
+      //! Beging chat parsing
+      this.logger.log(`Parsing live chat for stream ${streamInfo.id}`)
+      // Use first chat message as start of stream
+      const firstMessageTimestamp = chatJson[0].timestamp.toString()
+      const firstMessageEpoch = firstMessageTimestamp.slice(0, -3)
+      const startTime = new Date(parseInt(firstMessageEpoch))
+      // Loop over each chat message
+      for await (const message of chatJson) {
+        // First message or two is always blank for some reason
+        if (!message.message) {
+          continue
+        }
+        const messageTimestampRaw = message.timestamp.toString()
+        const messageTimestampEpoch = messageTimestampRaw.slice(0, -3)
+        const messageTimestamp = new Date(parseInt(messageTimestampEpoch))
+        // Calculate time offset since first message in seconds
+        const offsetSeconds = (messageTimestamp.getTime() - startTime.getTime()) / 1000
+        // Form new comment object that is supported by TwitchDownloader Chat Rendering
+        let comment = <any>{}
+        // Assign comment properties
+        comment._id = message.message_id
+        comment.source = "chat" // will always be chat
+        comment.content_offset_seconds = offsetSeconds
+        comment.commenter = {}
+        comment.commenter.display_name = message.author.display_name
+        comment.commenter.id = message.author.id
+        comment.commenter.is_moderator = message.author.is_moderator
+        comment.commenter.is_subscriber = message.author.is_subscriber
+        comment.commenter.is_turbo = message.author.is_turbo
+        comment.commenter.name = message.author.name
+        comment.message = {}
+        comment.message.body = message.message
+        comment.message.bits_spent = 0 // chat-downloader does not support bits
+        comment.message.fragments = [
+          {
+            text: message.message,
+            emoticon: null,
+          }
+        ]
+        comment.message.user_badges = []
+        comment.message.user_color = message.colour
+        comment.message.user_notice_params = {
+          "msg-id": null
+        }
+
+
+        // Push user badges to object
+        if (message.author.badges) {
+          for await (const badge of message.author.badges) {
+            let badgeObject = {}
+            badgeObject['_id'] = badge.name
+            badgeObject['version'] = badge.version
+            comment.message.user_badges.push(badgeObject)
+          }
+        }
+        // Some users don't have a color set
+        if (comment.message.user_color == "") {
+          comment.message.user_color = "#a65ee8"
+        }
+
+        // Push comment to new chat object
+        newChatJson.comments.push(comment)
+      }
+      // Write new chat object to file
+      fs.writeFileSync(`/tmp/${streamInfo.id}_live_chat.json`, JSON.stringify(newChatJson))
+      this.logger.log(`Raw stream chat parsed and saved to /tmp/${streamInfo.id}_live_chat.json`)
+    } catch (error) {
+      this.logger.error('Error parsing live chat file', error);
     }
   }
 }

--- a/src/live/dto/create-live.dto.ts
+++ b/src/live/dto/create-live.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from "class-validator";
+
+export class CreateLiveDto {
+    @IsString()
+    channel: string;
+}

--- a/src/live/dto/update-live.dto.ts
+++ b/src/live/dto/update-live.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateLiveDto } from './create-live.dto';
+
+export class UpdateLiveDto extends PartialType(CreateLiveDto) {}

--- a/src/live/dto/update-live.dto.ts
+++ b/src/live/dto/update-live.dto.ts
@@ -1,4 +1,8 @@
 import { PartialType } from '@nestjs/mapped-types';
+import { IsBoolean } from 'class-validator';
 import { CreateLiveDto } from './create-live.dto';
 
-export class UpdateLiveDto extends PartialType(CreateLiveDto) {}
+export class UpdateLiveDto extends PartialType(CreateLiveDto) {
+    @IsBoolean()
+    live: boolean
+}

--- a/src/live/entities/live.entity.ts
+++ b/src/live/entities/live.entity.ts
@@ -1,0 +1,22 @@
+import { Channel } from "src/channels/entities/channel.entity";
+import { User } from "src/users/entities/user.entity";
+import { Column, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class Live {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @OneToOne(() => Channel, { onDelete: 'CASCADE' })
+    @JoinColumn()
+    channel: Channel;
+
+    @ManyToOne(() => User, (user) => user.lives, { onDelete: 'CASCADE' })
+    user: User;
+
+    @Column({ default: false })
+    live: boolean
+
+    @Column({ nullable: true })
+    lastLive: Date
+}

--- a/src/live/live.controller.spec.ts
+++ b/src/live/live.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LiveController } from './live.controller';
+import { LiveService } from './live.service';
+
+describe('LiveController', () => {
+  let controller: LiveController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LiveController],
+      providers: [LiveService],
+    }).compile();
+
+    controller = module.get<LiveController>(LiveController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/live/live.controller.ts
+++ b/src/live/live.controller.ts
@@ -24,15 +24,15 @@ export class LiveController {
     return this.liveService.findAll();
   }
 
-  // @Get(':id')
-  // findOne(@Param('id') id: string) {
-  //   return this.liveService.findOne(+id);
-  // }
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.liveService.findOne(id);
+  }
 
-  // @Patch(':id')
-  // update(@Param('id') id: string, @Body() updateLiveDto: UpdateLiveDto) {
-  //   return this.liveService.update(+id, updateLiveDto);
-  // }
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateLiveDto: UpdateLiveDto) {
+    return this.liveService.update(id, updateLiveDto);
+  }
 
   @Delete(':id')
   remove(@Param('id') id: string) {

--- a/src/live/live.controller.ts
+++ b/src/live/live.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
+import { LiveService } from './live.service';
+import { CreateLiveDto } from './dto/create-live.dto';
+import { UpdateLiveDto } from './dto/update-live.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard } from 'src/auth/roles.guard';
+import { User, UserRole } from 'src/users/entities/user.entity';
+import { Roles } from 'src/auth/role.decorator';
+import { GetUser } from 'src/auth/get-user.decorator';
+
+@Controller({ path: 'live', version: '1' })
+export class LiveController {
+  constructor(private readonly liveService: LiveService) { }
+
+  @Post()
+  @UseGuards(AuthGuard(), RolesGuard)
+  @Roles(UserRole.ARCHIVER, UserRole.ADMIN)
+  create(@Body() createLiveDto: CreateLiveDto, @GetUser() user: User) {
+    return this.liveService.create(createLiveDto, user);
+  }
+
+  @Get()
+  findAll() {
+    return this.liveService.findAll();
+  }
+
+  // @Get(':id')
+  // findOne(@Param('id') id: string) {
+  //   return this.liveService.findOne(+id);
+  // }
+
+  // @Patch(':id')
+  // update(@Param('id') id: string, @Body() updateLiveDto: UpdateLiveDto) {
+  //   return this.liveService.update(+id, updateLiveDto);
+  // }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.liveService.remove(id);
+  }
+}

--- a/src/live/live.module.ts
+++ b/src/live/live.module.ts
@@ -1,0 +1,30 @@
+import { CacheModule, Module } from '@nestjs/common';
+import { LiveService } from './live.service';
+import { LiveController } from './live.controller';
+import { LiveRepository } from './live.repository';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from 'src/auth/auth.module';
+import { HttpModule } from '@nestjs/axios';
+import { ChannelsService } from 'src/channels/channels.service';
+import { ChannelsRepository } from 'src/channels/channels.repository';
+import { TwitchService } from 'src/twitch/twitch.service';
+import { FilesService } from 'src/files/files.service';
+import { ConfigService } from '@nestjs/config';
+import { VodsService } from 'src/vods/vods.service';
+import { VodsRepository } from 'src/vods/vods.repository';
+import { QueuesRepository } from 'src/queues/queues.repository';
+import { ExecService } from 'src/exec/exec.service';
+import { QueuesService } from 'src/queues/queues.service';
+import { UsersRepository } from 'src/users/users.repository';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([LiveRepository, ChannelsRepository, VodsRepository, QueuesRepository, UsersRepository]),
+    AuthModule,
+    CacheModule.register(),
+    HttpModule,
+  ],
+  controllers: [LiveController],
+  providers: [LiveService, ChannelsService, TwitchService, FilesService, ConfigService, VodsService, ExecService, QueuesService]
+})
+export class LiveModule { }

--- a/src/live/live.repository.ts
+++ b/src/live/live.repository.ts
@@ -1,0 +1,72 @@
+import {
+    ConflictException,
+    InternalServerErrorException,
+    Logger,
+    NotFoundException,
+} from '@nestjs/common';
+import { Live } from './entities/live.entity';
+import { EntityRepository, Repository } from 'typeorm';
+import { Channel } from 'src/channels/entities/channel.entity';
+import { User } from 'src/users/entities/user.entity';
+
+@EntityRepository(Live)
+export class LiveRepository extends Repository<Live> {
+    private logger = new Logger('LiveRepository');
+    async createLiveChannelWatch(channel: Channel, user: User): Promise<Live> {
+        try {
+            const live = this.create({
+                channel,
+                user,
+                live: false,
+            });
+            await this.save(live);
+            return live;
+        } catch (error) {
+            if (error.code === '23505') {
+                //duplicate
+                throw new ConflictException('Channel is already set to be watched.');
+            }
+            this.logger.error('Error creating channel', error);
+            throw new InternalServerErrorException("Error creating channel");
+        }
+    }
+    async removeLiveChannelWatch(channel: Channel) {
+        try {
+            const live = await this.findOne({
+                where: {
+                    channel,
+                },
+            });
+            await this.remove(live);
+        } catch (error) {
+            this.logger.error('Error removing channel', error);
+            throw new InternalServerErrorException("Error removing channel");
+        }
+    }
+    async findAll() {
+        return await this.find({ relations: ['channel'] });
+    }
+    async findAllNotLive() {
+        return await this.find({
+            where: {
+                live: false,
+            },
+            relations: ['channel', 'user'],
+        });
+    }
+    async updateLiveChannelStatus(channel: Channel, status: boolean): Promise<Live> {
+        try {
+            const live = await this.findOne({
+                where: {
+                    channel,
+                },
+                relations: ['channel'],
+            });
+            live.live = status;
+            await this.save(live);
+            return live;
+        } catch (error) {
+            this.logger.error('Error updating channel', error);
+        }
+    }
+}

--- a/src/live/live.repository.ts
+++ b/src/live/live.repository.ts
@@ -60,7 +60,7 @@ export class LiveRepository extends Repository<Live> {
                 where: {
                     channel,
                 },
-                relations: ['channel'],
+                relations: ['channel', 'user'],
             });
             live.live = status;
             await this.save(live);

--- a/src/live/live.repository.ts
+++ b/src/live/live.repository.ts
@@ -8,6 +8,7 @@ import { Live } from './entities/live.entity';
 import { EntityRepository, Repository } from 'typeorm';
 import { Channel } from 'src/channels/entities/channel.entity';
 import { User } from 'src/users/entities/user.entity';
+import { UpdateLiveDto } from './dto/update-live.dto';
 
 @EntityRepository(Live)
 export class LiveRepository extends Repository<Live> {
@@ -46,6 +47,13 @@ export class LiveRepository extends Repository<Live> {
     async findAll() {
         return await this.find({ relations: ['channel'] });
     }
+    async findById(id: string) {
+        try {
+            return await this.findOne(id, { relations: ['channel'] });
+        } catch (error) {
+            this.logger.error('Error finding channel', error);
+        }
+    }
     async findAllNotLive() {
         return await this.find({
             where: {
@@ -53,6 +61,16 @@ export class LiveRepository extends Repository<Live> {
             },
             relations: ['channel', 'user'],
         });
+    }
+    async updateLiveChannel(id: string, updateLiveDto: UpdateLiveDto) {
+        try {
+            const live = await this.findOne(id);
+            live.live = updateLiveDto.live;
+            await this.save(live);
+            return live;
+        } catch (error) {
+            this.logger.error('Error updating channel', error);
+        }
     }
     async updateLiveChannelStatus(channel: Channel, status: boolean): Promise<Live> {
         try {
@@ -66,7 +84,22 @@ export class LiveRepository extends Repository<Live> {
             await this.save(live);
             return live;
         } catch (error) {
-            this.logger.error('Error updating channel', error);
+            this.logger.error('Error updating channel status', error);
+        }
+    }
+    async updateLiveChannelLastLive(channel: Channel, lastLive: Date) {
+        try {
+            const live = await this.findOne({
+                where: {
+                    channel,
+                },
+                relations: ['channel', 'user'],
+            });
+            live.lastLive = lastLive;
+            await this.save(live);
+            return live;
+        } catch (error) {
+            this.logger.error('Error updating channel last live', error);
         }
     }
 }

--- a/src/live/live.service.spec.ts
+++ b/src/live/live.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LiveService } from './live.service';
+
+describe('LiveService', () => {
+  let service: LiveService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LiveService],
+    }).compile();
+
+    service = module.get<LiveService>(LiveService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/live/live.service.ts
+++ b/src/live/live.service.ts
@@ -99,7 +99,7 @@ export class LiveService {
           // channels in this loop are live, set them to live and proceed to archive
           for await (const [index, stream] of checkStreams.entries()) {
             // Update channel in live watch list
-            this.logger.log(`Channel ${stream.user_name} is live. Updating status in live watch list`);
+            this.logger.log(`Channel ${stream.user_name} is live.`);
             const live = await this.liveRepository.updateLiveChannelStatus(stream.user_id, true);
 
             // Create VOD item

--- a/src/live/live.service.ts
+++ b/src/live/live.service.ts
@@ -23,7 +23,7 @@ export class LiveService {
   ) { }
 
   // Check if channels are live (5 minutes)
-  @Cron(CronExpression.EVERY_5_SECONDS)
+  @Cron(CronExpression.EVERY_5_MINUTES)
   async handleCron() {
     this.logger.verbose('Checking if channels are live');
     await this.cronChannelLiveCheck();
@@ -117,9 +117,24 @@ export class LiveService {
       this.logger.error('Error checking if channels are live', error);
     }
   }
-  // findOne(id: number) {
-  //   return `This action returns a #${id} live`;
-  // }
+  async findOne(id: string) {
+    try {
+      const liveChannelEntry = await this.liveRepository.findById(id);
+      return liveChannelEntry
+    } catch (error) {
+      this.logger.error('Error finding live channel', error)
+      return new InternalServerErrorException("Error finding live channel");
+    }
+  }
+  async update(id: string, updateLiveDto: UpdateLiveDto) {
+    try {
+      const updateLiveChannel = await this.liveRepository.updateLiveChannel(id, updateLiveDto);
+      return updateLiveChannel
+    } catch (error) {
+      this.logger.error('Error updating live channel', error);
+      return new InternalServerErrorException("Error updating live channel");
+    }
+  }
 
   // update(id: number, updateLiveDto: UpdateLiveDto) {
   //   return `This action updates a #${id} live`;

--- a/src/live/live.service.ts
+++ b/src/live/live.service.ts
@@ -1,0 +1,142 @@
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ChannelsService } from 'src/channels/channels.service';
+import { Channel } from 'src/channels/entities/channel.entity';
+import { TwitchService } from 'src/twitch/twitch.service';
+import { User } from 'src/users/entities/user.entity';
+import { VodsService } from 'src/vods/vods.service';
+import { CreateLiveDto } from './dto/create-live.dto';
+import { UpdateLiveDto } from './dto/update-live.dto';
+import { Live } from './entities/live.entity';
+import { LiveRepository } from './live.repository';
+
+@Injectable()
+export class LiveService {
+  private logger = new Logger('LiveService');
+  constructor(
+    @InjectRepository(LiveRepository)
+    private liveRepository: LiveRepository,
+    private channelService: ChannelsService,
+    private twitchService: TwitchService,
+    private vodService: VodsService
+  ) { }
+
+  // Check if channels are live (5 minutes)
+  @Cron(CronExpression.EVERY_5_SECONDS)
+  async handleCron() {
+    this.logger.verbose('Checking if channels are live');
+    await this.cronChannelLiveCheck();
+  }
+
+  async create(createLiveDto: CreateLiveDto, user: User) {
+    // Find channel via supplied channel name
+    const channel = await this.channelService.findOne(createLiveDto.channel);
+    if (!channel) {
+      this.logger.error('Error finding channel with supplied name', createLiveDto.channel);
+      throw new InternalServerErrorException('Error finding channel with supplied name');
+    }
+    // Add channel to live watch list
+    const live = await this.liveRepository.createLiveChannelWatch(channel, user);
+
+    return live;
+  }
+
+  async findAll() {
+    try {
+      const live = this.liveRepository.findAll();
+      return live;
+    } catch (error) {
+      this.logger.error('Error finding all live channels', error);
+      return new InternalServerErrorException("Error finding all live channels");
+    }
+  }
+
+  // Internal
+  async findAllNotLive() {
+    try {
+      return await this.liveRepository.findAllNotLive();
+    } catch (error) {
+      this.logger.error("Error finding all not live channels", error);
+    }
+  }
+
+  // Internal
+  async updateLiveChannelStatus(channelId: string, status: boolean): Promise<Live> {
+    try {
+      const channel = await this.channelService.findOne(channelId);
+      if (!channel) {
+        this.logger.error('Error finding channel with supplied name from Twitch API checking live channels', channelId);
+      }
+      const live = await this.liveRepository.updateLiveChannelStatus(channel, status);
+      return live;
+    } catch (error) {
+      this.logger.error('Error updating channel status', error);
+    }
+  }
+
+  // Internal
+  async cronChannelLiveCheck() {
+    let queryString = ""
+    try {
+      const notLiveChannels = await this.liveRepository.findAllNotLive();
+      if (notLiveChannels.length > 0) {
+        for await (const [index, channel] of notLiveChannels.entries()) {
+          // Construct query string for twitch service and execute it...
+          const channelId = channel.channel.id
+          let tempQueryString
+          if (index === 0) {
+            tempQueryString = `?user_id=${channelId}`
+          } else {
+            tempQueryString = `&user_id=${channelId}`
+          }
+          queryString = queryString.concat(tempQueryString)
+        }
+        // Execute Twitch API call with query string
+        const checkStreams = await this.twitchService.getLiveInfoFromChannelId(queryString);
+        // checkStreams will be an array of objects with each object being a live channel
+        if (checkStreams.length > 0) {
+          // channels in this loop are live, set them to live and proceed to archive
+          for await (const [index, stream] of checkStreams.entries()) {
+            // Update channel in live watch list
+            this.logger.log(`Channel ${stream.user_name} is live. Updating status in live watch list`);
+            const live = await this.liveRepository.updateLiveChannelStatus(stream.user_id, true);
+
+            // Create VOD item
+            await this.vodService.createLiveVod(live, stream)
+            // Start video download
+            // Start chat download
+
+            // Create queue item
+
+          }
+        }
+      }
+
+    } catch (error) {
+      this.logger.error('Error checking if channels are live', error);
+    }
+  }
+  // findOne(id: number) {
+  //   return `This action returns a #${id} live`;
+  // }
+
+  // update(id: number, updateLiveDto: UpdateLiveDto) {
+  //   return `This action updates a #${id} live`;
+  // }
+
+  async remove(channelId: string) {
+    try {
+      const channel = await this.channelService.findOne(channelId);
+      if (!channel) {
+        this.logger.error('Error finding channel with supplied name', channelId);
+        throw new InternalServerErrorException('Error finding channel with supplied name');
+      }
+      await this.liveRepository.removeLiveChannelWatch(channel);
+      return "Channel removed from live watch list";
+    } catch (error) {
+      this.logger.error('Error removing channel', error);
+      return new InternalServerErrorException("Error removing channel");
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,9 @@ import { AppModule } from './app.module';
 import * as helmet from 'helmet';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    logger: process.env.LOG_LEVEL === 'debug' ? ['log', 'debug', 'error', 'verbose', 'warn'] : ['error', 'warn', 'log'],
+  });
   app.use(helmet());
   app.enableCors({
     origin: '*',

--- a/src/queues/dto/create-queue.dto.ts
+++ b/src/queues/dto/create-queue.dto.ts
@@ -15,4 +15,6 @@ export class CreateQueueDto {
   chatRenderDone: boolean;
   @IsBoolean()
   completed: boolean;
+  @IsString()
+  channelName: string;
 }

--- a/src/queues/entities/queue.entity.ts
+++ b/src/queues/entities/queue.entity.ts
@@ -38,6 +38,9 @@ export class Queue {
   @Column({ default: false })
   public completed: boolean;
 
+  @Column({ nullable: true })
+  public channelName: string
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/queues/entities/queue.entity.ts
+++ b/src/queues/entities/queue.entity.ts
@@ -20,9 +20,6 @@ export class Queue {
   @ManyToOne(() => User, (user) => user.queues, { onDelete: 'SET NULL' })
   user: User;
 
-  // @ManyToOne(() => Vod, (vod) => vod.queue)
-  // vod: Vod;
-
   @Column({ nullable: true })
   title: string;
 

--- a/src/queues/queues.module.ts
+++ b/src/queues/queues.module.ts
@@ -7,6 +7,7 @@ import { QueuesRepository } from './queues.repository';
 import { UsersRepository } from 'src/users/users.repository';
 import { HttpModule } from '@nestjs/axios';
 import { AuthModule } from 'src/auth/auth.module';
+import { LiveRepository } from 'src/live/live.repository';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { AuthModule } from 'src/auth/auth.module';
       VodsRepository,
       QueuesRepository,
       UsersRepository,
+      LiveRepository
     ]),
     HttpModule,
     AuthModule

--- a/src/queues/queues.repository.ts
+++ b/src/queues/queues.repository.ts
@@ -47,6 +47,7 @@ export class QueuesRepository extends Repository<Queue> {
     try {
       queue = this.create({
         vodId,
+        user: user,
         title,
         liveArchive,
         videoDone,

--- a/src/queues/queues.repository.ts
+++ b/src/queues/queues.repository.ts
@@ -42,6 +42,7 @@ export class QueuesRepository extends Repository<Queue> {
       chatDownloadDone,
       chatRenderDone,
       completed,
+      channelName
     } = createQueue;
     let queue: Queue;
     try {
@@ -54,6 +55,7 @@ export class QueuesRepository extends Repository<Queue> {
         chatDownloadDone,
         chatRenderDone,
         completed,
+        channelName
       });
       await this.save(queue);
     } catch (error) {

--- a/src/queues/queues.repository.ts
+++ b/src/queues/queues.repository.ts
@@ -47,7 +47,6 @@ export class QueuesRepository extends Repository<Queue> {
     try {
       queue = this.create({
         vodId,
-        user: user,
         title,
         liveArchive,
         videoDone,

--- a/src/queues/queues.service.ts
+++ b/src/queues/queues.service.ts
@@ -192,7 +192,7 @@ export class QueuesService {
             },
             {
               "name": "Live Archive",
-              "value": (queueItem.liveArchive) ? ':white_check_mark:' : ':x:',
+              "value": (queueItem.liveArchive) ? '✅' : '❌',
               "inline": true
             }
           ]

--- a/src/queues/queues.service.ts
+++ b/src/queues/queues.service.ts
@@ -92,8 +92,7 @@ export class QueuesService {
         }
       }
     } catch (error) {
-      this.logger.error(error);
-      throw new InternalServerErrorException();
+      this.logger.error("Error updating queue item final status or sending webhook", error);
     }
     await this.queuesRepository.save(queueItem);
   }

--- a/src/twitch/twitch.controller.ts
+++ b/src/twitch/twitch.controller.ts
@@ -3,7 +3,7 @@ import { TwitchService } from './twitch.service';
 
 @Controller({ path: 'twitch', version: '1' })
 export class TwitchController {
-  constructor(private readonly twitchService: TwitchService) {}
+  constructor(private readonly twitchService: TwitchService) { }
 
   @Get('/authenticate')
   async authenticate() {
@@ -18,5 +18,10 @@ export class TwitchController {
   @Get('/vods')
   async vods(@Query('id') id: string) {
     return await this.twitchService.getVodInfo(id);
+  }
+
+  @Get('/live')
+  async live(@Query('id') id: string) {
+    return await this.twitchService.getLiveInfo(id);
   }
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -29,7 +29,7 @@ export class User {
   @Column({ unique: true })
   username: string;
 
-  @Column()
+  @Column({ select: false })
   password: string;
 
   @Column({ nullable: true })

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,3 +1,4 @@
+import { Live } from 'src/live/entities/live.entity';
 import { Queue } from 'src/queues/entities/queue.entity';
 import {
   Entity,
@@ -21,6 +22,9 @@ export class User {
 
   @OneToMany(() => Queue, (queue) => queue.user, { onDelete: 'SET NULL' })
   queues: Queue[];
+
+  @OneToMany(() => Live, (live) => live.user, { onDelete: 'CASCADE' })
+  lives: Live[];
 
   @Column({ unique: true })
   username: string;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -106,7 +106,7 @@ export class UsersService {
     }
     let dbUser;
     try {
-      dbUser = await this.usersRepository.findOneOrFail({ id: user.id });
+      dbUser = await this.usersRepository.createQueryBuilder("user").where("user.id = :id", { id: user.id }).addSelect("user.password").getOne();
     } catch (error) {
       throw new NotFoundException('User not found');
     }

--- a/src/vods/vods.module.ts
+++ b/src/vods/vods.module.ts
@@ -38,4 +38,4 @@ import { UsersRepository } from 'src/users/users.repository';
     QueuesService,
   ],
 })
-export class VodsModule {}
+export class VodsModule { }

--- a/src/vods/vods.module.ts
+++ b/src/vods/vods.module.ts
@@ -14,6 +14,7 @@ import { QueuesRepository } from 'src/queues/queues.repository';
 import { ExecService } from 'src/exec/exec.service';
 import { QueuesService } from 'src/queues/queues.service';
 import { UsersRepository } from 'src/users/users.repository';
+import { LiveRepository } from 'src/live/live.repository';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { UsersRepository } from 'src/users/users.repository';
       ChannelsRepository,
       QueuesRepository,
       UsersRepository,
+      LiveRepository
     ]),
     AuthModule,
     CacheModule.register(),

--- a/src/vods/vods.repository.ts
+++ b/src/vods/vods.repository.ts
@@ -14,4 +14,13 @@ export class VodsRepository extends Repository<Vod> {
     }
     return vod;
   }
+  async updateVodLength(id: string, length: number) {
+    try {
+      const vod = await this.findOne({ where: { id } });
+      vod.duration = length;
+      await this.save(vod);
+    } catch (error) {
+      this.logger.error('Error updating vod duration', error);
+    }
+  }
 }

--- a/src/vods/vods.service.ts
+++ b/src/vods/vods.service.ts
@@ -28,6 +28,7 @@ import {
 import { Vod } from './entities/vod.entity';
 import { ManualCreateVodDto } from './dto/manual-create-vod.dto';
 import { Live } from 'src/live/entities/live.entity';
+import { UsersRepository } from 'src/users/users.repository';
 
 @Injectable()
 export class VodsService {
@@ -39,6 +40,8 @@ export class VodsService {
     private channelsRepository: ChannelsRepository,
     @InjectRepository(QueuesRepository)
     private queuesRepository: QueuesRepository,
+    @InjectRepository(UsersRepository)
+    private usersRepository: UsersRepository,
     private twitchService: TwitchService,
     private filesService: FilesService,
     private channelsService: ChannelsService,
@@ -385,7 +388,7 @@ export class VodsService {
       live.user
     );
 
-    this.execService.archiveLiveVideo(
+    this.execService.archiveLive(
       stream,
       'best',
       safeChannelName,

--- a/src/vods/vods.service.ts
+++ b/src/vods/vods.service.ts
@@ -121,6 +121,7 @@ export class VodsService {
       chatDownloadDone: false,
       chatRenderDone: false,
       completed: false,
+      channelName: checkChannel.displayName
     };
     const queue = await this.queuesRepository.createQueueItem(
       createQueue,
@@ -382,6 +383,7 @@ export class VodsService {
       chatDownloadDone: false,
       chatRenderDone: false,
       completed: false,
+      channelName: checkChannel.displayName
     };
     const queue = await this.queuesRepository.createQueueItem(
       createQueue,
@@ -393,6 +395,7 @@ export class VodsService {
       'best',
       safeChannelName,
       queue.id,
+      checkChannel
     );
     // await this.execService.archiveChat(vodInfo, safeChannelName, queue.id);
 


### PR DESCRIPTION
It's finally here! The ability to archive live streams. Channels can be added to a "live watch" list from the UI or through the API and every five minutes the channels are check if they're live. This feature supports downloading the video stream alongside the live chat. Once the stream ends the live chat will be rendered into a video similar to how VODs are archived right now. 

For a more in-depth look, visit the [Live Stream Archiving](https://github.com/Zibbp/Ceres/wiki/Live-Stream-Archiving) wiki page.