### PR TITLE
feat: Allow users set live cron schedules

### DIFF
--- a/src/config.schema.ts
+++ b/src/config.schema.ts
@@ -12,4 +12,5 @@ export const configValidationSchema = Joi.object({
   CLIENT_ID: Joi.string().required(),
   CLIENT_SECRET: Joi.string().required(),
   API_URL: Joi.string().required(),
+  LIVE_CRON_SCHEDULE: Joi.string(),
 });


### PR DESCRIPTION
Users now have the ability to set the schedule live channels are checked. This can be accomplished by adding an environment variable to the Ceres docker service.
```
LIVE_CRON_SCHEDULE=EVERY_10_MINUTES
```

For a list of valid cron expressions, visit the [NestJS schedule package](https://github.com/nestjs/schedule/blob/master/lib/enums/cron-expression.enum.ts). This variable will only accept the text cron expression and **not** the actual cron expression, example: `EVERY_MINUTE` is valid `*/1 * * * *` is **not** valid.

If the variable is not set it will default to 5 minutes. If the user enters an incorrect cron expression it will default to 5 minutes and notify them in the logs that it is incorrect.

Note: Values below five minutes may result in the thumbnail missing for live streams. This is because Twitch does not update thumbnails when the stream starts but instead on a schedule.